### PR TITLE
correct divide by zero error

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -328,7 +328,8 @@ class PerformanceStats(object):
             tot = tot + 1
             if mp[i] / mp[i - 11] > 1:
                 win = win + 1
-        self.twelve_month_win_perc = float(win) / tot
+        if tot != 0:
+            self.twelve_month_win_perc = float(win) / tot
 
         if len(yr) < 4:
             return


### PR DESCRIPTION
this error happens when calc 12 months win percentage with less than one year data